### PR TITLE
Add files via upload

### DIFF
--- a/notebooks/senzing-examples/python/senzing_init.ipynb
+++ b/notebooks/senzing-examples/python/senzing_init.ipynb
@@ -1,0 +1,125 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Default config already set\n",
+      "Stored 'senzing_config_dictionary' (str)\n"
+     ]
+    }
+   ],
+   "source": [
+    "python_path = \"{0}/python\".format(\n",
+    "    os.environ.get(\"SENZING_G2_DIR\", \"/opt/senzing/g2\"))\n",
+    "sys.path.append(python_path)\n",
+    "module_name = 'pyG2'\n",
+    "\n",
+    "config_path = os.environ.get(\"SENZING_ETC_DIR\", \"/etc/opt/senzing\")\n",
+    "support_path = os.environ.get(\"SENZING_DATA_VERSION_DIR\", \"/opt/senzing/data\")\n",
+    "\n",
+    "resource_path = \"{0}/resources\".format(\n",
+    "    os.environ.get(\"SENZING_G2_DIR\", \"/opt/senzing/g2\"))\n",
+    "\n",
+    "sql_connection = os.environ.get(\n",
+    "    \"SENZING_SQL_CONNECTION\", \"sqlite3://na:na@/opt/senzing/g2/sqldb/G2C.db\")\n",
+    "\n",
+    "verbose_logging = False\n",
+    "\n",
+    "senzing_config_dictionary = \"{\\\"PIPELINE\\\": {\\\"CONFIGPATH\\\" : \\\"/etc/opt/senzing\\\", \\\"SUPPORTPATH\\\": \\\"/opt/senzing/data/1.0.0\\\", \\\"RESOURCEPATH\\\": \\\"/opt/senzing/g2/resources\\\"}, \\\"SQL\\\": {\\\"CONNECTION\\\": \\\"sqlite3://na:na@/opt/senzing/g2/sqldb/G2C.db\\\"}}\"\n",
+    "\n",
+    "from G2ConfigMgr import G2ConfigMgr\n",
+    "g2_configuration_manager = G2ConfigMgr()\n",
+    "\n",
+    "return_code = g2_configuration_manager.initV2(\n",
+    "    module_name,\n",
+    "    senzing_config_dictionary,\n",
+    "    verbose_logging)\n",
+    "config_id_bytearray = bytearray(\"\", 'utf-8')\n",
+    "g2_configuration_manager.getDefaultConfigID(config_id_bytearray)\n",
+    "if(not config_id_bytearray):\n",
+    "    from G2Config import G2Config\n",
+    "\n",
+    "    g2_config = G2Config()\n",
+    "    g2_config.initV2(module_name, senzing_config_dictionary, verbose_logging)\n",
+    "\n",
+    "    # Create configuration from template file.\n",
+    "    config_handle = g2_config.create()\n",
+    "\n",
+    "    # Save JSON to string variable.\n",
+    "\n",
+    "    response_bytearray = bytearray(\"\", 'utf-8')\n",
+    "    return_code = g2_config.save(config_handle, response_bytearray)\n",
+    "    senzing_model_config_json = response_bytearray.decode()\n",
+    "    config_comment = \"Configuration added from G2SetupConfig.\"\n",
+    "    config_id_bytearray = bytearray(\"\", 'utf-8')\n",
+    "    return_code = g2_configuration_manager.addConfig(\n",
+    "        senzing_model_config_json,\n",
+    "        config_comment,\n",
+    "        config_id_bytearray)\n",
+    "    configID = bytearray(\"\", 'utf-8')\n",
+    "    return_code = g2_configuration_manager.setDefaultConfigID(config_id_bytearray)\n",
+    "else:\n",
+    "    print(\"Default config already set\")\n",
+    "%store senzing_config_dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #78 



Each notebook can now get rid of the "initialize variables" step and replace it with the two commands, 
"%run senzing_Init.ipynb" (this should run the init notebook which will check if there is a default configuration set and will set one if there is not.)

"%store -r senzing_config_dictionary" (this will set the variable "senzing_config_dictionary"[or whatever it happens to get named] in the current notebook. This is the json of the PIPLELINE and SQL paths, just like the old senzing_config_dictionary)